### PR TITLE
Added switch to skip CFUN=0 on INIT

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -39,6 +39,7 @@ config_schema:
   - ["pppos.hexdump_enable", "b", false, {title: "Dump all the data sent over UART to stderr"}]
   - ["pppos.last_oper", "s", "", {title: "This field is used to store last successfully connected operator"}]
   - ["pppos.reg_cmd", "s", "CREG", {title: "AT command used for setting and checking network registration. CREG(default), CGREG, CEREG"}]
+  - ["pppos.cfun_cycle", "b", true, {title: "Set CFUN to 0, then to 1"}]
 
 conds:
   # ESP32 sets LwIP options via sdkconfig, for other platforms use cdefs directly.

--- a/src/mgos_pppos.c
+++ b/src/mgos_pppos.c
@@ -673,7 +673,9 @@ static void mgos_pppos_dispatch_once(struct mgos_pppos_data *pd) {
       add_cmd(pd, mgos_pppos_at_cb, 0, "AT");
       add_cmd(pd, NULL, 0, "ATH");
       add_cmd(pd, NULL, 0, "ATE0");
-      if (mgos_sys_config_get_pppos_cfun_cycle()) add_cmd(pd, NULL, 0, "AT+CFUN=0"); /* Offline */
+      if (mgos_sys_config_get_pppos_cfun_cycle()) {
+        add_cmd(pd, NULL, 0, "AT+CFUN=0"); /* Offline */
+      }
       if (!pd->baud_ok) {
         struct mgos_uart_config ucfg;
         bool need_ifr = true, need_ifc = true;

--- a/src/mgos_pppos.c
+++ b/src/mgos_pppos.c
@@ -673,7 +673,7 @@ static void mgos_pppos_dispatch_once(struct mgos_pppos_data *pd) {
       add_cmd(pd, mgos_pppos_at_cb, 0, "AT");
       add_cmd(pd, NULL, 0, "ATH");
       add_cmd(pd, NULL, 0, "ATE0");
-      add_cmd(pd, NULL, 0, "AT+CFUN=0"); /* Offline */
+      if (mgos_sys_config_get_pppos_cfun_cycle()) add_cmd(pd, NULL, 0, "AT+CFUN=0"); /* Offline */
       if (!pd->baud_ok) {
         struct mgos_uart_config ucfg;
         bool need_ifr = true, need_ifc = true;


### PR DESCRIPTION
Doing CFUN=0 makes my ME lose registration on boot, making reconnects on boot slower than they should be.

Added a switch to skip setting CFUN=0. Entry `pppos.cfun_cycle`